### PR TITLE
Non null String

### DIFF
--- a/lib/src/linux_system_info_base.dart
+++ b/lib/src/linux_system_info_base.dart
@@ -10,10 +10,10 @@ class SystemInfo {
   String kernel_version = '';
 
   /// Current os name, e.g.: `Ubuntu`
-  String? os_name = '';
+  String os_name = '';
 
   /// Current os version, e.g.: `21.04`
-  String? os_version = '';
+  String os_version = '';
 
   /// A parsing of `/etc/os-release` containing information like the distro codename and homepage
   Map<String, String> os_release = <String, String>{};
@@ -30,8 +30,8 @@ class SystemInfo {
       os_release[data[0]] = data[1].replaceAll('\"', '');
     }
 
-    os_name = os_release['NAME'];
-    os_version = os_release['VERSION_ID'];
+    os_name = os_release['NAME'] ?? '';
+    os_version = os_release['VERSION_ID'] ?? '';
   }
 }
 


### PR DESCRIPTION
@LolzDEV
In my last PR I made `os_name` and `os_version` nullable. But now I'm trying to integrate your library into a real app, I don't think it is a good idea.
In fact, actually when I want to create a `Text` widget in flutter, I have to do this:

```dart
Text(SystemInfo().os_name ?? '')
```

And if I want to mix `os_name` and `os_version`:

```dart
Text((SystemInfo().os_name ?? '') + ' ' + (SystemInfo().os_version ?? ''))

// Instead of:

Text(SystemInfo().os_name + ' ' + SystemInfo().os_version)
```

And it's really annoying because it is just because only these two vars are nullable.
So I'm really sorry to create this patch PR.