### PR TITLE
Add GpuInfo

### DIFF
--- a/example/linux_system_info_example.dart
+++ b/example/linux_system_info_example.dart
@@ -1,6 +1,6 @@
 import 'package:linux_system_info/linux_system_info.dart';
 
-void main() {
+Future<void> main() async {
   //CPU
 
   var cpu_usage = CpuInfo
@@ -19,6 +19,11 @@ void main() {
 
   var total_swap = MemInfo()
       .swap_total_gb; // This returns the amount of SWAP in GB (you can also get it in kb or mb) e.g. 2
+
+  //GPU
+
+  var gpu_model = (await GpuInfo.load())[0]
+      .model; // This returns the model name of the GPU e.g. "Intel HD Graphics"
 
   //SYSTEM
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,6 @@ dev_dependencies:
   pedantic: ^1.9.0
   test: ^1.14.4
 dependencies:
+  dbus: ^0.6.3
+  ffi: ^1.1.2
   tuple: ^2.0.0


### PR DESCRIPTION
For example:
```dart
final gpus = await GpuInfo.load();
print(gpus.first.model); // "Intel Corporation Iris Xe Graphics"
```

Fetches the GPU information from (same as gnome-control-center):

- `net.hadess.SwitcherooControl.GPUs` (D-Bus)
- `org.gnome.SessionManager.Renderer` (D-Bus)
- `GL_RENDERER` (OpenGL)